### PR TITLE
Update ShareContentProvider.java

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/ShareContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/ShareContentProvider.java
@@ -174,7 +174,7 @@ public class ShareContentProvider extends CustomContentProvider {
                 }
                 default:
                     //To break the switch
-                    break;
+                    continue;
             }
         }
 


### PR DESCRIPTION
using break inside the default case was breaking the loop. Used continue instead

